### PR TITLE
Implement spark application to read XML from GCS and write to BigQuery.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,5 @@
+libraryDependencies += Seq(
+  "com.databricks:spark-xml_2.12",
+  "com.google.cloud:spark-bigquery_1.0.0-alpha",
+  "com.google.cloud:spark-gcs-connector_1.0.0-alpha"
+)

--- a/spark_app.py
+++ b/spark_app.py
@@ -1,0 +1,23 @@
+from pyspark.sql import SparkSession
+from pyspark import SparkContext
+from google.cloud import storage
+from google.cloud import bigquery
+
+def main():
+    # Create a Spark session
+    spark = SparkSession.builder.appName("XMLToBigQuery").getOrCreate()
+    spark_context = SparkContext()
+
+    # Configure GCS connector
+    conf = {"spark.hadoop.fs.gcs.impl.disable.cache.validation": "true"}
+    spark.sparkContext.setConf(conf)
+
+    # Read XML from GCS
+    gcs_path = "gs://gcptraining-350417/spark-repo/claim.xml" 
+    xml_df = spark.read.format("xml").option("rowTag", "ROW").load(gcs_path)
+
+    # Write to BigQuery
+    xml_df.write.format("bigquery").mode("overwrite").option("temporaryGcsBucket", "gcptraining-350417").save("gcptraining-350417.medicare.claim_table")
+
+if __name__ == "__main__":
+    main()

--- a/test_spark_app.py
+++ b/test_spark_app.py
@@ -1,0 +1,23 @@
+from pyspark.sql import SparkSession
+from pyspark import SparkContext
+from pyspark.sql.functions import col
+
+def test_xml_to_bigquery():
+    """
+    Tests the spark_app.py functionality by reading from the bigquery table.
+    """
+    # Create a Spark session
+    spark = SparkSession.builder.appName("XMLToBigQueryTest").getOrCreate()
+    spark_context = SparkContext()
+
+    # Read data from bigquery table
+    bq_df = spark.read.format("bigquery").load("gcptraining-350417.medicare.claim_table")
+
+    # Expected data
+    expected_data = [{"provider_id":"123"}, {"provider_id":"456"}]
+    
+    # Check if data matches with expected data
+    assert bq_df.select("provider_id").rdd.collect() == expected_data
+
+if __name__ == "__main__":
+    test_xml_to_bigquery()


### PR DESCRIPTION
The application reads XML data from a specified GCS path and writes it to a designated BigQuery table. Dependencies for Spark XML, BigQuery, and GCS have been added. A test file was created to check if the application is writing data to BigQuery.